### PR TITLE
Refactor FiguraLuaPrinter.getTypeColor to be more concise and, slightly more importantly, correct

### DIFF
--- a/common/src/main/java/org/figuramc/figura/lua/FiguraLuaPrinter.java
+++ b/common/src/main/java/org/figuramc/figura/lua/FiguraLuaPrinter.java
@@ -347,8 +347,8 @@ public class FiguraLuaPrinter {
             case LuaValue.TTABLE -> ColorUtils.Colors.PURPLE.style;
             case LuaValue.TNIL -> ColorUtils.Colors.LUA_ERROR.style;
             case LuaValue.TBOOLEAN -> ColorUtils.Colors.LUA_PING.style;
-            case LuaValue.TLIGHTUSERDATA -> ColorUtils.Colors.BLUE.style;
-            case LuaValue.TNUMBER -> Style.EMPTY.withColor(ChatFormatting.GREEN);
+            case LuaValue.TNUMBER -> ColorUtils.Colors.BLUE.style;
+            case LuaValue.TSTRING -> Style.EMPTY.withColor(ChatFormatting.GREEN);
             case LuaValue.TUSERDATA -> Style.EMPTY.withColor(ChatFormatting.YELLOW);
             case LuaValue.TTHREAD -> Style.EMPTY.withColor(ChatFormatting.GOLD);
         	default -> Style.EMPTY.withColor(ChatFormatting.WHITE);

--- a/common/src/main/java/org/figuramc/figura/lua/FiguraLuaPrinter.java
+++ b/common/src/main/java/org/figuramc/figura/lua/FiguraLuaPrinter.java
@@ -343,17 +343,16 @@ public class FiguraLuaPrinter {
     }
 
     private static Style getTypeColor(LuaValue value) {
-
-        switch(value.type()){
-            case 5: return ColorUtils.Colors.PURPLE.style; // Table
-            case 0: return ColorUtils.Colors.LUA_ERROR.style; // Nil
-            case 1: return ColorUtils.Colors.LUA_PING.style; // Bool
-            case 2: return ColorUtils.Colors.BLUE.style; // Number
-            case 3: return Style.EMPTY.withColor(ChatFormatting.GREEN); // String
-            case 7: return Style.EMPTY.withColor(ChatFormatting.YELLOW); // Userdate
-            case 8: return Style.EMPTY.withColor(ChatFormatting.GOLD); // Thread
-        	default: return Style.EMPTY.withColor(ChatFormatting.WHITE); // Your mother
-        }
+        return switch (value.type()) {
+            case LuaValue.TTABLE -> ColorUtils.Colors.PURPLE.style;
+            case LuaValue.TNIL -> ColorUtils.Colors.LUA_ERROR.style;
+            case LuaValue.TBOOLEAN -> ColorUtils.Colors.LUA_PING.style;
+            case LuaValue.TLIGHTUSERDATA -> ColorUtils.Colors.BLUE.style;
+            case LuaValue.TNUMBER -> Style.EMPTY.withColor(ChatFormatting.GREEN);
+            case LuaValue.TUSERDATA -> Style.EMPTY.withColor(ChatFormatting.YELLOW);
+            case LuaValue.TTHREAD -> Style.EMPTY.withColor(ChatFormatting.GOLD);
+        	default -> Style.EMPTY.withColor(ChatFormatting.WHITE);
+        };
     }
 
     // -- SLOW PRINTING OF LOG --// 


### PR DESCRIPTION
While trying to cleverly shorten `FiguraLuaPrinter.getTypeColor` (f68612f4472e729d3dbd33c3f2e36d87e6c70b3a), you made a typo. This PR consists of two commits: one to shorten even more cleverly and highlight the typo, and one to fix the typo.

To add insult to injury, as any good PR should do: you spelled userdata wrong.